### PR TITLE
Holdings editor

### DIFF
--- a/src/components/DetailsPanelHoldings.vue
+++ b/src/components/DetailsPanelHoldings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Holding, type EquipmentItem, type Unit } from "@orbat-mapper/msdllib";
+import { Holding, type EquipmentItem, type HoldingType, type Unit } from "@orbat-mapper/msdllib";
 import {
   Table,
   TableBody,
@@ -24,7 +24,7 @@ const props = defineProps<{
   item: Unit | EquipmentItem;
 }>();
 
-function onUpdate(data: Partial<Holding>[]) {
+function onUpdate(data: HoldingType[]) {
   toggleEditDialog();
   updateHoldings(props.item.objectHandle, data);
 }
@@ -51,6 +51,7 @@ function onUpdate(data: Partial<Holding>[]) {
       :parent-name="item.name"
       @cancel="toggleEditDialog"
       @update="onUpdate"
+      @update:open="toggleEditDialog"
     />
     <Table class="">
       <TableHeader>

--- a/src/components/HoldingsEditDialog.vue
+++ b/src/components/HoldingsEditDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Holding } from "@orbat-mapper/msdllib";
+import type { HoldingType } from "@orbat-mapper/msdllib";
 import {
   Dialog,
   DialogContent,
@@ -16,15 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
+import { FormControl, FormField, FormItem, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import FormFooter from "@/components/FormFooter.vue";
 import { Button } from "@/components/ui/button";
@@ -35,18 +27,18 @@ import * as z from "zod";
 
 const open = defineModel<boolean>("open", { required: true });
 
-const props = defineProps<{ holdings: Array<Partial<Holding>>; parentName: string }>();
+const props = defineProps<{ holdings: Array<HoldingType>; parentName: string }>();
 const emit = defineEmits<{
   (e: "cancel"): void;
-  (e: "update", value: Array<Partial<Holding>>): void;
+  (e: "update", value: Array<HoldingType>): void;
 }>();
 
 const formSchema = toTypedSchema(
   z.object({
     holdings: z.array(
       z.object({
-        nsnName: z.string().min(1, "Name is required"),
-        nsnCode: z.string(),
+        nsnName: z.string(),
+        nsnCode: z.string().min(1, "NSN Code is required"),
         onHandQuantity: z.number(),
       }),
     ),
@@ -63,7 +55,7 @@ const form = useForm({
 const { remove, push, fields } = useFieldArray("holdings");
 
 const onSubmit = form.handleSubmit((values) => {
-  console.log(JSON.stringify(values, null, 2));
+  console.log("Updating holdings");
   emit("update", values.holdings);
 });
 
@@ -98,9 +90,9 @@ console.log(`Dialog`);
           </TableHeader>
           <TableBody>
             <TableRow v-for="(field, i) in fields" :key="field.key">
-              <TableCell class="w-1/3">
+              <TableCell class="w-1/3 align-top">
                 <FormField
-                  v-slot="{ componentField }"
+                  v-slot="{ componentField, errorMessage }"
                   :name="`holdings[${i}].nsnName`"
                   :validate-on-blur="!form.isFieldDirty"
                 >
@@ -108,12 +100,13 @@ console.log(`Dialog`);
                     <FormControl>
                       <Input type="text" placeholder="" v-bind="componentField" />
                     </FormControl>
+                    <FormMessage v-if="errorMessage">{{ errorMessage }}</FormMessage>
                   </FormItem>
                 </FormField>
               </TableCell>
-              <TableCell class="w-1/3">
+              <TableCell class="w-1/3 align-top">
                 <FormField
-                  v-slot="{ componentField }"
+                  v-slot="{ componentField, errorMessage }"
                   :name="`holdings[${i}].nsnCode`"
                   :validate-on-blur="!form.isFieldDirty"
                 >
@@ -121,12 +114,13 @@ console.log(`Dialog`);
                     <FormControl>
                       <Input type="text" placeholder="" v-bind="componentField" />
                     </FormControl>
+                    <FormMessage v-if="errorMessage">{{ errorMessage }}</FormMessage>
                   </FormItem>
                 </FormField>
               </TableCell>
-              <TableCell class="w-1/3">
+              <TableCell class="w-1/3 align-top">
                 <FormField
-                  v-slot="{ componentField }"
+                  v-slot="{ componentField, errorMessage }"
                   :name="`holdings[${i}].onHandQuantity`"
                   :validate-on-blur="!form.isFieldDirty"
                 >
@@ -134,6 +128,7 @@ console.log(`Dialog`);
                     <FormControl>
                       <Input type="number" placeholder="" v-bind="componentField" />
                     </FormControl>
+                    <FormMessage v-if="errorMessage">{{ errorMessage }}</FormMessage>
                   </FormItem>
                 </FormField>
               </TableCell>
@@ -145,7 +140,10 @@ console.log(`Dialog`);
             </TableRow>
             <TableRow class="hover:!bg-transparent">
               <TableCell :colspan="4" class="text-center">
-                <Button variant="secondary" @click.stop="push({ nsnName: '', nsnCode: '', onHandQuantity: 0 })">
+                <Button
+                  variant="secondary"
+                  @click.stop="push({ nsnName: '', nsnCode: '', onHandQuantity: 0 })"
+                >
                   Add holding<CirclePlus />
                 </Button>
               </TableCell>

--- a/src/stores/scanarioStore.ts
+++ b/src/stores/scanarioStore.ts
@@ -1,11 +1,10 @@
 import { computed, shallowRef, triggerRef } from "vue";
-import { Holding, MilitaryScenario, ScenarioId } from "@orbat-mapper/msdllib";
+import { Holding, MilitaryScenario, ScenarioId, type HoldingType } from "@orbat-mapper/msdllib";
 import { useLayerStore } from "@/stores/layerStore.ts";
 import { useSelectStore } from "@/stores/selectStore.ts";
 import type { ScenarioIdType } from "@orbat-mapper/msdllib/dist/lib/scenarioid";
 import { parseFromString, xmlToString } from "@/utils.ts";
 import type { Position } from "geojson";
-import { createXMLElement } from "@orbat-mapper/msdllib/dist/lib/domutils";
 
 export interface MetaEntry<T = string> {
   label: T;
@@ -86,7 +85,7 @@ function updateScenarioId(value: Partial<ScenarioIdType>) {
     if (key in v) {
       (v as any)[key] = value;
     } else {
-      console.warn(`Property ${key} does not exist on Holding class.`);
+      console.warn(`Property ${key} does not exist on ScenarioIdType class.`);
     }
   });
   const postSnapshot = xmlToString(msdl.value.scenarioId.element);
@@ -165,20 +164,40 @@ function updateItemLocation(objectHandle: string, newLocation: Position) {
   // console.warn("Not implemented yet: updateItemLocation", newLocation);
 }
 
-function updateHoldings(objectHandle: string, newHoldings: Partial<Holding>[]) {
+function updateHoldings(objectHandle: string, newHoldings: HoldingType[]) {
   if (!msdl.value) return;
   const item = msdl.value.getUnitById(objectHandle) ?? msdl.value.getEquipmentById(objectHandle);
   if (!item) {
     console.warn(`Unit/EquipmentItem with object handle ${objectHandle} not found.`);
     return;
   }
+  // TODO: implement a smarter merge between existing item.holdings and newHoldings
   const holdingObjects = newHoldings.map((h) => {
-    const e = createXMLElement("<Holding></Holding>");
-    const newHolding = new Holding(e);
+    const newHolding = Holding.fromModel(h);
     newHolding.updateFromObject(h);
     return newHolding;
   });
+
+  // TODO: undo/redo functionality
+  // const preSnapshot = xmlToString(item.element);
   item.holdings = holdingObjects;
+  // const postSnapshot = xmlToString(item.element);
+  // const inversePatches: Patch[] = [
+  //   {
+  //     op: "replace",
+  //     path: ["PATH_TO_UNIT"],
+  //     value: preSnapshot,
+  //   },
+  // ];
+  // const patches: Patch[] = [
+  //   {
+  //     op: "replace",
+  //     path: ["PATH_TO_UNIT"],
+  //     value: postSnapshot,
+  //   },
+  // ];
+  // undoStack.value.push({ patches, inversePatches });
+  // redoStack.value.splice(0);
   triggerRef(msdl);
 }
 


### PR DESCRIPTION
Add an editor for adding and editing holdings of Unit/EquipmentItem. Is working and changes are reflected in the MSDL scenario. One flaw is that the item property of the `DetailsPanelHoldings` does not change after editing the Holdings. Switching back and forth to another tab does trigger the updated values to show. One solution could be to make the `activeItem` in  the `selectStore` an `ref` instead of the `shallowRef` it is now. Would that be an option?

Needs https://github.com/orbat-mapper/msdllib/pull/18 to be merged first (and resulting dependency version bump)

![image](https://github.com/user-attachments/assets/8f1c2030-066d-4f41-9932-275b682cc340)
