### PR TITLE
Tweak search results to ensure that both units and equipment are included

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,3 +168,14 @@ export function groupBy<T extends object, K extends keyof T>(arr: T[], key: K) {
     return acc;
   }, new Map<T[K], T[]>());
 }
+
+export function groupByObj<T extends object, K extends keyof T>(arr: T[], key: K) {
+  return arr.reduce(
+    (acc, item) => {
+      const k = String(item[key] as unknown);
+      (acc[k] = acc[k] || []).push(item);
+      return acc;
+    },
+    {} as Record<string, T[]>,
+  );
+}


### PR DESCRIPTION
Previously equipment was only included if there were less than 10 unit hits
