### PR TITLE
Add geo name search to command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@tmcw/togeojson": "^7.1.2",
     "@turf/bbox": "^7.2.0",
     "@turf/centroid": "^7.2.0",
+    "@turf/distance": "^7.3.1",
     "@turf/helpers": "^7.3.1",
     "@vee-validate/zod": "^4.15.1",
     "@vueuse/core": "^13.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@turf/centroid':
         specifier: ^7.2.0
         version: 7.3.1
+      '@turf/distance':
+        specifier: ^7.3.1
+        version: 7.3.1
       '@turf/helpers':
         specifier: ^7.3.1
         version: 7.3.1
@@ -1172,8 +1175,14 @@ packages:
   '@turf/centroid@7.3.1':
     resolution: {integrity: sha512-hRnsDdVBH4pX9mAjYympb2q5W8TCMUMNEjcRrAF7HTCyjIuRmjJf8vUtlzf7TTn9RXbsvPc1vtm3kLw20Jm8DQ==}
 
+  '@turf/distance@7.3.1':
+    resolution: {integrity: sha512-DK//doTGgYYjBkcWUywAe7wbZYcdP97hdEJ6rXYVYRoULwGGR3lhY96GNjozg6gaW9q2eSNYnZLpcL5iFVHqgw==}
+
   '@turf/helpers@7.3.1':
     resolution: {integrity: sha512-zkL34JVhi5XhsuMEO0MUTIIFEJ8yiW1InMu4hu/oRqamlY4mMoZql0viEmH6Dafh/p+zOl8OYvMJ3Vm3rFshgg==}
+
+  '@turf/invariant@7.3.1':
+    resolution: {integrity: sha512-IdZJfDjIDCLH+Gu2yLFoSM7H23sdetIo5t4ET1/25X8gi3GE2XSqbZwaGjuZgNh02nisBewLqNiJs2bo+hrqZA==}
 
   '@turf/meta@7.3.1':
     resolution: {integrity: sha512-NWsfOE5RVtWpLQNkfOF/RrYvLRPwwruxhZUV0UFIzHqfiRJ50aO9Y6uLY4bwCUe2TumLJQSR4yaoA72Rmr2mnQ==}
@@ -3759,8 +3768,21 @@ snapshots:
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
+  '@turf/distance@7.3.1':
+    dependencies:
+      '@turf/helpers': 7.3.1
+      '@turf/invariant': 7.3.1
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@turf/helpers@7.3.1':
     dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/invariant@7.3.1':
+    dependencies:
+      '@turf/helpers': 7.3.1
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 

--- a/src/components/commandpalette/CommandPaletteDialog.vue
+++ b/src/components/commandpalette/CommandPaletteDialog.vue
@@ -36,8 +36,9 @@ const forwarded = useForwardPropsEmits(props, emits);
         <DialogDescription>{{ description }}</DialogDescription>
       </DialogHeader>
       <slot v-bind="slotProps" />
-      <DialogFooter class="p-2 text-sm text-muted-foreground"
-        >Type <Kbd>&gt;</Kbd> or <Kbd>#</Kbd> for actions</DialogFooter
+      <DialogFooter class="p-2 text-sm text-muted-foreground sm:justify-start"
+        >Type <Kbd>@</Kbd> for place name search, <Kbd>&gt;</Kbd> or <Kbd>#</Kbd> for
+        actions</DialogFooter
       >
     </DialogContent>
   </Dialog>

--- a/src/components/commandpalette/CommandPalettePlaceItem.vue
+++ b/src/components/commandpalette/CommandPalettePlaceItem.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { MapPinIcon, SquareIcon } from "lucide-vue-next";
+
+import { type GeoSearchProperties, type PhotonSearchResult } from "@/composables/geosearching";
+import type { Feature, Point } from "geojson";
+
+import { distance } from "@turf/distance";
+import { formatLength } from "@/utils.ts";
+
+const props = defineProps<{
+  item: PhotonSearchResult;
+  center?: number[] | null;
+}>();
+
+function getFromCenter(f: Feature<Point, GeoSearchProperties>) {
+  const length =
+    props.center && distance(props.center, f.geometry.coordinates, { units: "meters" });
+  return length ? formatLength(length) : "";
+}
+</script>
+
+<template>
+  <div class="justify-center flex w-6">
+    <component
+      :is="item.properties.extent ? SquareIcon : MapPinIcon"
+      class="h-5 w-5 text-gray-400"
+      aria-hidden="true"
+    />
+  </div>
+  <div class="grid grid-cols-[auto,1fr] w-full">
+    <span>{{ item.properties.name }}</span>
+    <div class="text-sm text-muted-foreground flex justify-between w-full">
+      <div class="space-x-1">
+        <span class="uppercase">{{ item.properties.category }}</span>
+        <span>{{ item.properties.city }}</span>
+        <span>{{ item.properties.state }}</span>
+        <span>{{ item.properties.country }}</span>
+      </div>
+      <span class="">{{ getFromCenter(item) }}</span>
+    </div>
+  </div>
+</template>

--- a/src/composables/geosearching.ts
+++ b/src/composables/geosearching.ts
@@ -1,0 +1,72 @@
+import { ref } from "vue";
+import { useFetch } from "@vueuse/core";
+import type { Feature, FeatureCollection, Point } from "geojson";
+
+export interface GeoSearchOptions {
+  mapCenter?: number[] | null;
+  limit?: number;
+  lang?: string;
+}
+
+export interface PhotonFeatureProperties {
+  name: string;
+  country?: string;
+  city?: string;
+  state?: string;
+  extent?: number[];
+  osm_key?: string;
+}
+
+export interface GeoSearchProperties {
+  name: string;
+  country?: string;
+  city?: string;
+  state?: string;
+  extent?: number[];
+  category?: string;
+  distance?: number;
+}
+
+export type PhotonSearchResult = Feature<Point, GeoSearchProperties>;
+
+export interface ExtendedPhotonSearchResult extends PhotonSearchResult {
+  category: "Places";
+}
+
+export function useGeoSearch() {
+  const searchUrl = ref("");
+  const { data, isFetching, error, execute } = useFetch(searchUrl, {
+    immediate: false,
+  })
+    .get()
+    .json<FeatureCollection<Point, PhotonFeatureProperties>>();
+
+  async function photonSearch(
+    q: string,
+    options: GeoSearchOptions = {},
+  ): Promise<PhotonSearchResult[]> {
+    const { mapCenter, limit = 10, lang = "en" } = options;
+    searchUrl.value = `https://photon.komoot.io/api/?q=${q}&limit=${limit}&lang=${lang}`;
+    if (mapCenter) {
+      const [lon, lat] = mapCenter;
+      searchUrl.value += `&lon=${lon}&lat=${lat}`;
+    }
+    await execute();
+    if (data.value) {
+      return data.value.features.map((item) => {
+        return {
+          ...item,
+          properties: {
+            name: item.properties.name,
+            country: item.properties.country,
+            city: item.properties.city,
+            state: item.properties.state,
+            extent: item.properties.extent,
+            category: item.properties.osm_key,
+          },
+        } as PhotonSearchResult;
+      });
+    } else return [];
+  }
+  return { isFetching, photonSearch };
+}

--- a/src/composables/scenarioActions.ts
+++ b/src/composables/scenarioActions.ts
@@ -9,6 +9,8 @@ import { isForceSide, isUnitOrEquipment, triggerFlash } from "@/utils.ts";
 import maplibregl, { type LngLatBoundsLike, type LngLatLike } from "maplibre-gl";
 import bbox from "@turf/bbox";
 import type { GeoJSON } from "geojson";
+import type { PhotonSearchResult } from "@/composables/geosearching.ts";
+import { fixExtent } from "@/lib/geoConvert.ts";
 
 export type ScenarioAction =
   | "CreateNewMSDL"
@@ -137,6 +139,22 @@ export function flyToItem(
     }
     mlMap?.fitBounds(bounds as LngLatBoundsLike, {
       padding: { top: 50, bottom: 50, left: 200, right: 200 },
+    });
+  }
+}
+
+export function flyToPlace(item: PhotonSearchResult, mlMap: maplibregl.Map) {
+  const extent = fixExtent(item.properties.extent);
+  if (extent) {
+    mlMap?.fitBounds(extent as LngLatBoundsLike, {
+      maxZoom: 15,
+      duration: 1500,
+    });
+  } else {
+    mlMap?.flyTo({
+      center: item.geometry.coordinates as LngLatLike,
+      zoom: 15,
+      duration: 1500,
     });
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,3 +179,31 @@ export function groupByObj<T extends object, K extends keyof T>(arr: T[], key: K
     {} as Record<string, T[]>,
   );
 }
+
+export type MeasurementUnit = "metric" | "imperial" | "nautical";
+
+export function formatLength(length: number, unit: MeasurementUnit = "metric") {
+  let output: string = "";
+  if (unit === "metric") {
+    if (length > 100) {
+      output = Math.round((length / 1000) * 100) / 100 + " km";
+    } else {
+      output = Math.round(length * 100) / 100 + " m";
+    }
+  } else if (unit === "imperial") {
+    const miles = length * 0.000621371192;
+    if (miles > 0.1) {
+      output = miles.toFixed(2) + " mi";
+    } else {
+      output = (miles * 5280).toFixed(2) + " ft";
+    }
+  } else if (unit === "nautical") {
+    const nm = length * 0.000539956803;
+    if (nm > 0.1) {
+      output = nm.toFixed(2) + " nm";
+    } else {
+      output = nm.toFixed(3) + " nm";
+    }
+  }
+  return output;
+}


### PR DESCRIPTION
This PR adds geo search to the command palette. To start a geo search prefix the query with `@`.

<img width="1088" height="864" alt="image" src="https://github.com/user-attachments/assets/b2c358cb-c86e-418f-b385-fd6c8486c51a" />

Thanks to https://photon.komoot.io/ for providing the API!